### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Spring XD RPM should now be available in `rpmbuild/RPMS/noarch`
 
 ### Building Spring XD Release RPM with Vagrant
 
-You need to install [Vagrant](http://docs.vagrantup.com/v2/installation/) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads). Then add the `chef/centos-6.5` box for VirtualBox.
+You need to install [Vagrant](https://docs.vagrantup.com/v2/installation/) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads). Then add the `chef/centos-6.5` box for VirtualBox.
 
 We are providing a Vagrant file for easy building of the RPM. Follow these steps from the root directory of this project:
 
@@ -39,7 +39,7 @@ The first time the VM is started we should install `rpm-build`
 Now copy the Spring XD release distribution zip file (set XD_VERSION to the correct version):
 
     $ export XD_VERSION='{new-release-version}'
-    $ export XD_REPO='http://repo.spring.io/libs-release-local'
+    $ export XD_REPO='https://repo.spring.io/libs-release-local'
     $ wget -P rpmbuild/SOURCES  ${XD_REPO}/org/springframework/xd/spring-xd/${XD_VERSION}/spring-xd-${XD_VERSION}-dist.zip
 
 Finally build the RPM:

--- a/rpmbuild/SPECS/spring-xd-noarch.spec
+++ b/rpmbuild/SPECS/spring-xd-noarch.spec
@@ -9,7 +9,7 @@ Group:          Applications/Databases
 License:        Apache License v2.0
 Vendor:         Pivotal
 Packager:       spring-xd@pivotal.io
-URL:            http://projects.spring.io/spring-xd
+URL:            https://projects.spring.io/spring-xd
 
 # Disable automatic dependency processing
 #####AutoReqProv: no


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.vagrantup.com/v2/installation/ with 1 occurrences migrated to:  
  https://docs.vagrantup.com/v2/installation/ ([https](https://docs.vagrantup.com/v2/installation/) result 301).
* [ ] http://projects.spring.io/spring-xd with 1 occurrences migrated to:  
  https://projects.spring.io/spring-xd ([https](https://projects.spring.io/spring-xd) result 301).
* [ ] http://repo.spring.io/libs-release-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).